### PR TITLE
Fix Ansible install via GitHub

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,14 @@ user=$(whoami)
 
 function Install_Ansible {
 
-    apt-get update
-    apt-get install -y software-properties-common
-    apt-add-repository -y ppa:ansible/ansible
-    apt-get update
-    apt-get install -y ansible
+    apt-get install python-setuptools
+    easy_install pip
+    cd ..
+    git clone https://github.com/ansible/ansible.git
+    cd ansible
+    git checkout v2.3.2.0-1
+    pip install -r ./requirements.txt
+    source ./hacking/env-setup
 
 }
 


### PR DESCRIPTION
Using ansible@2.3.2.0-1 to install this repo, because the dependancy.
Because new version (2.4) of ansible released, installation of OpenNet failed.
As shown:
![opennet](https://user-images.githubusercontent.com/16065669/30644877-736e9c90-9e46-11e7-8ae7-fa034198d371.jpg)

